### PR TITLE
Implement PatternLayout

### DIFF
--- a/src/jsMain/kotlin/lumberjack/sawtooth/layout/componentRegistry.kt
+++ b/src/jsMain/kotlin/lumberjack/sawtooth/layout/componentRegistry.kt
@@ -11,4 +11,5 @@ internal var _componentRegistry: Map<String, PatternComponent> = mapOf(
     "cause" to CauseComponent
 )
 
-internal actual val componentRegistry: Map<String, PatternComponent> by _componentRegistry
+internal actual val componentRegistry: Map<String, PatternComponent>
+    get() = _componentRegistry

--- a/src/jsMain/kotlin/lumberjack/sawtooth/layout/componentRegistry.kt
+++ b/src/jsMain/kotlin/lumberjack/sawtooth/layout/componentRegistry.kt
@@ -1,15 +1,25 @@
+/*
+ * This file is part of Lumberjack.
+ *
+ * Lumberjack is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Lumberjack is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Lumberjack.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package lumberjack.sawtooth.layout
 
 import lumberjack.sawtooth.component.*
 
-internal var _componentRegistry: Map<String, PatternComponent> = mapOf(
-    "msg" to MessageComponent,
-    "level" to LevelComponent,
-    "logger" to LoggerComponent,
-    "marker" to MarkerComponent,
-    "mdc" to MDCComponent,
-    "cause" to CauseComponent
-)
+internal var _componentRegistry: Map<String, PatternComponentInitialiser> = PatternLayout.defaultComponentRegistry
 
-internal actual val componentRegistry: Map<String, PatternComponent>
+public actual var PatternLayout.Factory.componentRegistry: Map<String, PatternComponentInitialiser>
     get() = _componentRegistry
+    set(value) = value.run { _componentRegistry = this }

--- a/src/jsMain/kotlin/lumberjack/sawtooth/layout/componentRegistry.kt
+++ b/src/jsMain/kotlin/lumberjack/sawtooth/layout/componentRegistry.kt
@@ -1,0 +1,14 @@
+package lumberjack.sawtooth.layout
+
+import lumberjack.sawtooth.component.*
+
+internal var _componentRegistry: Map<String, PatternComponent> = mapOf(
+    "msg" to MessageComponent,
+    "level" to LevelComponent,
+    "logger" to LoggerComponent,
+    "marker" to MarkerComponent,
+    "mdc" to MDCComponent,
+    "cause" to CauseComponent
+)
+
+internal actual val componentRegistry: Map<String, PatternComponent> by _componentRegistry

--- a/src/nativeMain/kotlin/lumberjack/sawtooth/layout/componentRegistry.kt
+++ b/src/nativeMain/kotlin/lumberjack/sawtooth/layout/componentRegistry.kt
@@ -1,16 +1,26 @@
+/*
+ * This file is part of Lumberjack.
+ *
+ * Lumberjack is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Lumberjack is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Lumberjack.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package lumberjack.sawtooth.layout
 
 import lumberjack.sawtooth.component.*
 import kotlin.native.concurrent.AtomicReference
 
-internal val _componentRegistry = AtomicReference(mapOf(
-    "msg" to MessageComponent,
-    "level" to LevelComponent,
-    "logger" to LoggerComponent,
-    "marker" to MarkerComponent,
-    "mdc" to MDCComponent,
-    "cause" to CauseComponent
-))
+private val _componentRegistry = AtomicReference(PatternLayout.defaultComponentRegistry)
 
-internal actual val componentRegistry: Map<String, PatternComponent>
+public actual var PatternLayout.Factory.componentRegistry: Map<String, PatternComponentInitialiser>
     get() = _componentRegistry.value
+    set(value) = value.run { _componentRegistry.value = this }

--- a/src/nativeMain/kotlin/lumberjack/sawtooth/layout/componentRegistry.kt
+++ b/src/nativeMain/kotlin/lumberjack/sawtooth/layout/componentRegistry.kt
@@ -1,0 +1,16 @@
+package lumberjack.sawtooth.layout
+
+import lumberjack.sawtooth.component.*
+import kotlin.native.concurrent.AtomicReference
+
+internal val _componentRegistry = AtomicReference(mapOf(
+    "msg" to MessageComponent,
+    "level" to LevelComponent,
+    "logger" to LoggerComponent,
+    "marker" to MarkerComponent,
+    "mdc" to MDCComponent,
+    "cause" to CauseComponent
+))
+
+internal actual val componentRegistry: Map<String, PatternComponent>
+    get() = _componentRegistry.value

--- a/src/sawtoothMain/kotlin/lumberjack/sawtooth/Configuration.kt
+++ b/src/sawtoothMain/kotlin/lumberjack/sawtooth/Configuration.kt
@@ -48,3 +48,6 @@ data class Configuration private constructor(
         )
     }
 }
+
+inline fun <T> withProperties(vararg properties: LogProperty<*>, block: (properties: Set<LogProperty<*>>, keys: Set<PropertyKey<*>>) -> T): T =
+    block(properties.toSet(), properties.map(LogProperty<*>::key).toSet())

--- a/src/sawtoothMain/kotlin/lumberjack/sawtooth/Configuration.kt
+++ b/src/sawtoothMain/kotlin/lumberjack/sawtooth/Configuration.kt
@@ -19,6 +19,8 @@ package lumberjack.sawtooth
 import lumberjack.sawtooth.appender.Appender
 import lumberjack.sawtooth.appender.RegexCompositeAppender
 import lumberjack.sawtooth.event.LogEventFactory
+import lumberjack.sawtooth.event.LogProperty
+import lumberjack.sawtooth.event.PropertyKey
 import lumberjack.sawtooth.event.ThreadLocalLogEventFactory
 import lumberjack.sawtooth.level.LevelFactory
 import lumberjack.sawtooth.level.RegexLevelFactory
@@ -49,5 +51,8 @@ data class Configuration private constructor(
     }
 }
 
+inline fun <T> withProperties(properties: Iterable<LogProperty<*>>, block: (properties: Set<LogProperty<*>>, keys: Set<PropertyKey<*>>) -> T): T =
+    block(properties.toSet(), properties.mapTo(LinkedHashSet(), LogProperty<*>::key))
+
 inline fun <T> withProperties(vararg properties: LogProperty<*>, block: (properties: Set<LogProperty<*>>, keys: Set<PropertyKey<*>>) -> T): T =
-    block(properties.toSet(), properties.map(LogProperty<*>::key).toSet())
+    block(properties.toSet(), properties.mapTo(LinkedHashSet(properties.size), LogProperty<*>::key))

--- a/src/sawtoothMain/kotlin/lumberjack/sawtooth/component/CauseComponent.kt
+++ b/src/sawtoothMain/kotlin/lumberjack/sawtooth/component/CauseComponent.kt
@@ -1,0 +1,19 @@
+package lumberjack.sawtooth.component
+
+import lumberjack.sawtooth.event.LogEvent
+
+object CauseComponent : PatternComponent {
+    override fun writeTo(builder: StringBuilder, event: LogEvent) {
+        var cause = event.cause
+        while (cause != null) {
+            builder.append("\nCaused by: ")
+
+            builder.append(cause::class.simpleName)
+            builder.append(" (")
+            builder.append(cause.message)
+            builder.append(')')
+
+            cause = cause.cause
+        }
+    }
+}

--- a/src/sawtoothMain/kotlin/lumberjack/sawtooth/component/CauseComponent.kt
+++ b/src/sawtoothMain/kotlin/lumberjack/sawtooth/component/CauseComponent.kt
@@ -1,3 +1,19 @@
+/*
+ * This file is part of Lumberjack.
+ *
+ * Lumberjack is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Lumberjack is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Lumberjack.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package lumberjack.sawtooth.component
 
 import lumberjack.sawtooth.event.LogEvent

--- a/src/sawtoothMain/kotlin/lumberjack/sawtooth/component/LevelComponent.kt
+++ b/src/sawtoothMain/kotlin/lumberjack/sawtooth/component/LevelComponent.kt
@@ -1,0 +1,9 @@
+package lumberjack.sawtooth.component
+
+import lumberjack.sawtooth.event.LogEvent
+
+object LevelComponent : PatternComponent {
+    override fun writeTo(builder: StringBuilder, event: LogEvent) {
+        builder.append(event.level.name)
+    }
+}

--- a/src/sawtoothMain/kotlin/lumberjack/sawtooth/component/LevelComponent.kt
+++ b/src/sawtoothMain/kotlin/lumberjack/sawtooth/component/LevelComponent.kt
@@ -1,3 +1,19 @@
+/*
+ * This file is part of Lumberjack.
+ *
+ * Lumberjack is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Lumberjack is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Lumberjack.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package lumberjack.sawtooth.component
 
 import lumberjack.sawtooth.event.LogEvent

--- a/src/sawtoothMain/kotlin/lumberjack/sawtooth/component/LoggerComponent.kt
+++ b/src/sawtoothMain/kotlin/lumberjack/sawtooth/component/LoggerComponent.kt
@@ -1,0 +1,9 @@
+package lumberjack.sawtooth.component
+
+import lumberjack.sawtooth.event.LogEvent
+
+object LoggerComponent : PatternComponent {
+    override fun writeTo(builder: StringBuilder, event: LogEvent) {
+        builder.append(event.logger.name)
+    }
+}

--- a/src/sawtoothMain/kotlin/lumberjack/sawtooth/component/LoggerComponent.kt
+++ b/src/sawtoothMain/kotlin/lumberjack/sawtooth/component/LoggerComponent.kt
@@ -1,3 +1,19 @@
+/*
+ * This file is part of Lumberjack.
+ *
+ * Lumberjack is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Lumberjack is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Lumberjack.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package lumberjack.sawtooth.component
 
 import lumberjack.sawtooth.event.LogEvent

--- a/src/sawtoothMain/kotlin/lumberjack/sawtooth/component/MDCComponent.kt
+++ b/src/sawtoothMain/kotlin/lumberjack/sawtooth/component/MDCComponent.kt
@@ -1,3 +1,19 @@
+/*
+ * This file is part of Lumberjack.
+ *
+ * Lumberjack is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Lumberjack is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Lumberjack.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package lumberjack.sawtooth.component
 
 import lumberjack.MDC

--- a/src/sawtoothMain/kotlin/lumberjack/sawtooth/component/MDCComponent.kt
+++ b/src/sawtoothMain/kotlin/lumberjack/sawtooth/component/MDCComponent.kt
@@ -1,0 +1,10 @@
+package lumberjack.sawtooth.component
+
+import lumberjack.MDC
+import lumberjack.sawtooth.event.LogEvent
+
+object MDCComponent : PatternComponent {
+    override fun writeTo(builder: StringBuilder, event: LogEvent) {
+        event.context[MDC]?.takeIf(MDC::isNotEmpty)?.let(builder::append)
+    }
+}

--- a/src/sawtoothMain/kotlin/lumberjack/sawtooth/component/MarkerComponent.kt
+++ b/src/sawtoothMain/kotlin/lumberjack/sawtooth/component/MarkerComponent.kt
@@ -1,3 +1,19 @@
+/*
+ * This file is part of Lumberjack.
+ *
+ * Lumberjack is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Lumberjack is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Lumberjack.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package lumberjack.sawtooth.component
 
 import lumberjack.sawtooth.event.LogEvent

--- a/src/sawtoothMain/kotlin/lumberjack/sawtooth/component/MarkerComponent.kt
+++ b/src/sawtoothMain/kotlin/lumberjack/sawtooth/component/MarkerComponent.kt
@@ -1,0 +1,9 @@
+package lumberjack.sawtooth.component
+
+import lumberjack.sawtooth.event.LogEvent
+
+object MarkerComponent : PatternComponent {
+    override fun writeTo(builder: StringBuilder, event: LogEvent) {
+        event.marker?.run { builder.append(name) }
+    }
+}

--- a/src/sawtoothMain/kotlin/lumberjack/sawtooth/component/MessageComponent.kt
+++ b/src/sawtoothMain/kotlin/lumberjack/sawtooth/component/MessageComponent.kt
@@ -1,3 +1,19 @@
+/*
+ * This file is part of Lumberjack.
+ *
+ * Lumberjack is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Lumberjack is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Lumberjack.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package lumberjack.sawtooth.component
 
 import lumberjack.sawtooth.event.LogEvent

--- a/src/sawtoothMain/kotlin/lumberjack/sawtooth/component/MessageComponent.kt
+++ b/src/sawtoothMain/kotlin/lumberjack/sawtooth/component/MessageComponent.kt
@@ -1,0 +1,8 @@
+package lumberjack.sawtooth.component
+
+import lumberjack.sawtooth.event.LogEvent
+
+object MessageComponent : PatternComponent {
+    override fun writeTo(builder: StringBuilder, event: LogEvent): Unit =
+        event.message.writeTo(builder)
+}

--- a/src/sawtoothMain/kotlin/lumberjack/sawtooth/component/PatternComponent.kt
+++ b/src/sawtoothMain/kotlin/lumberjack/sawtooth/component/PatternComponent.kt
@@ -1,9 +1,26 @@
+/*
+ * This file is part of Lumberjack.
+ *
+ * Lumberjack is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Lumberjack is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Lumberjack.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package lumberjack.sawtooth.component
 
 import lumberjack.sawtooth.event.LogEvent
 import lumberjack.sawtooth.layout.Layout
 
+public typealias PatternComponentInitialiser=(modifiers: List<String>) -> PatternComponent
+
 interface PatternComponent: Layout {
     override fun writeTo(builder: StringBuilder, event: LogEvent)
-    fun tune(modifiers: List<String>) {}
 }

--- a/src/sawtoothMain/kotlin/lumberjack/sawtooth/component/PatternComponent.kt
+++ b/src/sawtoothMain/kotlin/lumberjack/sawtooth/component/PatternComponent.kt
@@ -1,0 +1,9 @@
+package lumberjack.sawtooth.component
+
+import lumberjack.sawtooth.event.LogEvent
+import lumberjack.sawtooth.layout.Layout
+
+interface PatternComponent: Layout {
+    override fun writeTo(builder: StringBuilder, event: LogEvent)
+    fun tune(modifiers: List<String>) {}
+}

--- a/src/sawtoothMain/kotlin/lumberjack/sawtooth/component/PropertyComponent.kt
+++ b/src/sawtoothMain/kotlin/lumberjack/sawtooth/component/PropertyComponent.kt
@@ -1,17 +1,27 @@
+/*
+ * This file is part of Lumberjack.
+ *
+ * Lumberjack is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Lumberjack is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Lumberjack.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package lumberjack.sawtooth.component
 
 import lumberjack.sawtooth.event.LogEvent
 import lumberjack.sawtooth.event.PropertyKey
 
 open class PropertyComponent<T : Any>(val property: PropertyKey<T>) : PatternComponent {
-    private var formatOptions: List<String> = emptyList()
-
     override fun writeTo(builder: StringBuilder, event: LogEvent) {
         builder.append(event.property(property)?.let(this::format))
-    }
-
-    override fun tune(modifiers: List<String>) {
-        formatOptions = modifiers
     }
 
     open fun format(property: T): String = property.toString()

--- a/src/sawtoothMain/kotlin/lumberjack/sawtooth/component/PropertyComponent.kt
+++ b/src/sawtoothMain/kotlin/lumberjack/sawtooth/component/PropertyComponent.kt
@@ -1,0 +1,18 @@
+package lumberjack.sawtooth.component
+
+import lumberjack.sawtooth.event.LogEvent
+import lumberjack.sawtooth.event.PropertyKey
+
+open class PropertyComponent<T : Any>(val property: PropertyKey<T>) : PatternComponent {
+    private var formatOptions: List<String> = emptyList()
+
+    override fun writeTo(builder: StringBuilder, event: LogEvent) {
+        builder.append(event.property(property)?.let(this::format))
+    }
+
+    override fun tune(modifiers: List<String>) {
+        formatOptions = modifiers
+    }
+
+    open fun format(property: T): String = property.toString()
+}

--- a/src/sawtoothMain/kotlin/lumberjack/sawtooth/component/RawComponent.kt
+++ b/src/sawtoothMain/kotlin/lumberjack/sawtooth/component/RawComponent.kt
@@ -1,3 +1,19 @@
+/*
+ * This file is part of Lumberjack.
+ *
+ * Lumberjack is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Lumberjack is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Lumberjack.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package lumberjack.sawtooth.component
 
 import lumberjack.sawtooth.event.LogEvent

--- a/src/sawtoothMain/kotlin/lumberjack/sawtooth/component/RawComponent.kt
+++ b/src/sawtoothMain/kotlin/lumberjack/sawtooth/component/RawComponent.kt
@@ -1,0 +1,11 @@
+package lumberjack.sawtooth.component
+
+import lumberjack.sawtooth.event.LogEvent
+
+data class RawComponent(val string: String) : PatternComponent {
+    constructor(value: Any?) : this(value.toString())
+
+    override fun writeTo(builder: StringBuilder, event: LogEvent) {
+        builder.append(string)
+    }
+}

--- a/src/sawtoothMain/kotlin/lumberjack/sawtooth/event/LambdaLogProperty.kt
+++ b/src/sawtoothMain/kotlin/lumberjack/sawtooth/event/LambdaLogProperty.kt
@@ -1,9 +1,0 @@
-package lumberjack.sawtooth.event
-
-class LambdaLogProperty<T : Any>(override val key: PropertyKey<T>, val supply: (LogEvent) -> T?) : LogProperty<T> {
-    companion object {
-        inline operator fun <reified T : Any> invoke(name: String, noinline supply: (LogEvent) -> T?): LambdaLogProperty<T> = LambdaLogProperty(PropertyKey(name, T::class), supply)
-    }
-
-    override fun value(event: LogEvent): T? = supply(event)
-}

--- a/src/sawtoothMain/kotlin/lumberjack/sawtooth/event/LambdaLogProperty.kt
+++ b/src/sawtoothMain/kotlin/lumberjack/sawtooth/event/LambdaLogProperty.kt
@@ -1,0 +1,9 @@
+package lumberjack.sawtooth.event
+
+class LambdaLogProperty<T : Any>(override val key: PropertyKey<T>, val supply: (LogEvent) -> T?) : LogProperty<T> {
+    companion object {
+        inline operator fun <reified T : Any> invoke(name: String, noinline supply: (LogEvent) -> T?): LambdaLogProperty<T> = LambdaLogProperty(PropertyKey(name, T::class), supply)
+    }
+
+    override fun value(event: LogEvent): T? = supply(event)
+}

--- a/src/sawtoothMain/kotlin/lumberjack/sawtooth/event/LogProperty.kt
+++ b/src/sawtoothMain/kotlin/lumberjack/sawtooth/event/LogProperty.kt
@@ -18,6 +18,13 @@ package lumberjack.sawtooth.event
 
 interface LogProperty<T : Any> {
 
+    companion object Factory {
+        inline fun <reified T : Any> fromName(name: String, crossinline block: (LogEvent) -> T?): LogProperty<T> = object : LogProperty<T> {
+            override val key: PropertyKey<T> = PropertyKey(name, T::class)
+            override fun value(event: LogEvent): T? = block(event)
+        }
+    }
+
     val key: PropertyKey<T>
 
     fun value(event: LogEvent): T?

--- a/src/sawtoothMain/kotlin/lumberjack/sawtooth/layout/PatternLayout.kt
+++ b/src/sawtoothMain/kotlin/lumberjack/sawtooth/layout/PatternLayout.kt
@@ -21,6 +21,7 @@ import lumberjack.sawtooth.event.LogEvent
 import lumberjack.sawtooth.event.PropertyKey
 
 class PatternLayout(val components: List<PatternComponent>) : Layout {
+    @Suppress("RedundantLambdaArrow")
     companion object Factory {
         //language=RegExp
         /** Matches an opening brace, followed by one or more word characters [0-9a-zA-Z_], followed by a closing brace */
@@ -41,15 +42,15 @@ class PatternLayout(val components: List<PatternComponent>) : Layout {
         private val tokenModifierRegex = TOKEN_MODIFIER_PATTERN.toRegex()
 
         internal val defaultComponentRegistry: Map<String, PatternComponentInitialiser> = mapOf(
-            "m" to { MessageComponent },
-            "msg" to { MessageComponent },
-            "message" to { MessageComponent },
-            "lvl" to { LevelComponent },
-            "level" to { LevelComponent },
-            "logger" to { LoggerComponent },
-            "marker" to { MarkerComponent },
-            "mdc" to { MDCComponent },
-            "cause" to { CauseComponent }
+            "m" to { _: List<String> -> MessageComponent },
+            "msg" to { _: List<String> -> MessageComponent },
+            "message" to { _: List<String> -> MessageComponent },
+            "lvl" to { _: List<String> -> LevelComponent },
+            "level" to { _: List<String> -> LevelComponent },
+            "logger" to { _: List<String> -> LoggerComponent },
+            "marker" to { _: List<String> -> MarkerComponent },
+            "mdc" to { _: List<String> -> MDCComponent },
+            "cause" to { _: List<String> -> CauseComponent }
         )
 
         fun fromPattern(pattern: String, loggerProperties: Set<PropertyKey<*>> = emptySet(), localRegistry: Map<String, PatternComponentInitialiser> = emptyMap()): PatternLayout {

--- a/src/sawtoothMain/kotlin/lumberjack/sawtooth/layout/PatternLayout.kt
+++ b/src/sawtoothMain/kotlin/lumberjack/sawtooth/layout/PatternLayout.kt
@@ -1,0 +1,52 @@
+package lumberjack.sawtooth.layout
+
+import lumberjack.sawtooth.component.PatternComponent
+import lumberjack.sawtooth.component.PropertyComponent
+import lumberjack.sawtooth.component.RawComponent
+import lumberjack.sawtooth.event.LogEvent
+import lumberjack.sawtooth.event.PropertyKey
+
+class PatternLayout(val components: Array<PatternComponent>) : Layout {
+    companion object {
+        //language=RegExp
+        const val TOKEN_MODIFIER_PATTERN = "\\{(\\w+)\\}"
+        private val tokenRegex = "(?<=[^%]|^)%(?:(\\w+)|(?:\\[(\\w+)\\]))((?:$TOKEN_MODIFIER_PATTERN)*)".toRegex()
+        private val tokenModifierRegex = TOKEN_MODIFIER_PATTERN.toRegex()
+
+        fun fromPattern(pattern: String, loggerProperties: Set<PropertyKey<*>> = emptySet(), localRegistry: Map<String, PatternComponent> = emptyMap()): PatternLayout {
+            var start = 0
+            var tokenMatch = tokenRegex.find(pattern, start)
+            val components: MutableList<PatternComponent> = ArrayList()
+            val localRegistry = componentRegistry + localRegistry + loggerProperties.associate { key -> Pair(key.name, PropertyComponent(key)) }
+
+            while (tokenMatch != null) {
+                if (tokenMatch.range.first > start) {
+                    components.add(RawComponent(pattern.substring(start, tokenMatch.range.first)))
+                }
+
+                val token = tokenMatch.groupValues[1]
+
+                val component = localRegistry[token]
+                if (component != null) {
+                    component.tune(tokenModifierRegex.findAll(tokenMatch.groupValues[3]).map { result -> result.groupValues[1] }.toList())
+                    components.add(component)
+                }
+
+                start = tokenMatch.range.last + 1
+                tokenMatch = tokenRegex.find(pattern, start)
+            }
+
+            if (start < pattern.length) {
+                components.add(RawComponent(pattern.substring(start)))
+            }
+
+            return PatternLayout(components.toTypedArray())
+        }
+    }
+
+    override fun writeTo(builder: StringBuilder, event: LogEvent) {
+        components.forEach { it.writeTo(builder, event) }
+    }
+}
+
+internal expect val componentRegistry: Map<String, PatternComponent>

--- a/src/sawtoothMain/kotlin/lumberjack/sawtooth/layout/PatternLayout.kt
+++ b/src/sawtoothMain/kotlin/lumberjack/sawtooth/layout/PatternLayout.kt
@@ -1,46 +1,101 @@
+/*
+ * This file is part of Lumberjack.
+ *
+ * Lumberjack is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Lumberjack is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Lumberjack.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package lumberjack.sawtooth.layout
 
-import lumberjack.sawtooth.component.PatternComponent
-import lumberjack.sawtooth.component.PropertyComponent
-import lumberjack.sawtooth.component.RawComponent
+import lumberjack.sawtooth.component.*
 import lumberjack.sawtooth.event.LogEvent
 import lumberjack.sawtooth.event.PropertyKey
 
-class PatternLayout(val components: Array<PatternComponent>) : Layout {
-    companion object {
+class PatternLayout(val components: List<PatternComponent>) : Layout {
+    companion object Factory {
         //language=RegExp
+        /** Matches an opening brace, followed by one or more word characters [0-9a-zA-Z_], followed by a closing brace */
         const val TOKEN_MODIFIER_PATTERN = "\\{(\\w+)\\}"
+
+        /**
+         * Regex is notoriously hellish, so let's run through what this does
+         * This is a regex string to match a token - that is, a percent sign '%' followed by one or more word characters, optionally enclosed with brackets
+         * The regex functions like so:
+         * - `(?<=[^%]|^)` Requires the first character to either be anything *other* than a percent sign, *or* have it be the start of the string. Does not match that character.
+         * - `%` Match a single percent sign
+         * - `(?:(\w+)|(?:\[(\w+)\]))` Use a non-capturing group to select one of two options - either match one or more word characters, or match an opening bracket, one or more word characters, and then a closing bracket
+         * - `((?:$TOKEN_MODIFIER_PATTERN)*)` Use a non-capturing group to match the token modifier pattern zero or more times, and capture that whole result
+         */
         private val tokenRegex = "(?<=[^%]|^)%(?:(\\w+)|(?:\\[(\\w+)\\]))((?:$TOKEN_MODIFIER_PATTERN)*)".toRegex()
+
+        /** Because regex can't capture a group multiple times, we need a separate regex to find all matches in the modifier match */
         private val tokenModifierRegex = TOKEN_MODIFIER_PATTERN.toRegex()
 
-        fun fromPattern(pattern: String, loggerProperties: Set<PropertyKey<*>> = emptySet(), localRegistry: Map<String, PatternComponent> = emptyMap()): PatternLayout {
-            var start = 0
-            var tokenMatch = tokenRegex.find(pattern, start)
-            val components: MutableList<PatternComponent> = ArrayList()
-            val localRegistry = componentRegistry + localRegistry + loggerProperties.associate { key -> Pair(key.name, PropertyComponent(key)) }
+        internal val defaultComponentRegistry: Map<String, PatternComponentInitialiser> = mapOf(
+            "m" to { MessageComponent },
+            "msg" to { MessageComponent },
+            "message" to { MessageComponent },
+            "lvl" to { LevelComponent },
+            "level" to { LevelComponent },
+            "logger" to { LoggerComponent },
+            "marker" to { MarkerComponent },
+            "mdc" to { MDCComponent },
+            "cause" to { CauseComponent }
+        )
 
+        fun fromPattern(pattern: String, loggerProperties: Set<PropertyKey<*>> = emptySet(), localRegistry: Map<String, PatternComponentInitialiser> = emptyMap()): PatternLayout {
+            val components: MutableList<PatternComponent> = ArrayList()
+            val modifiers: MutableList<String> = ArrayList()
+
+            //Compile a map of initialisers from our global registry, our local registry, and the properties that have been passed in
+            val registry =
+                componentRegistry +
+                localRegistry +
+                loggerProperties.associate { key -> Pair(key.name, { PropertyComponent(key) }) }
+
+            var start = 0
+            //Find our first match in the pattern
+            var tokenMatch = tokenRegex.find(pattern, start)
+
+            //While we have a valid match
             while (tokenMatch != null) {
+                //If the match is further into the string than the starting position, we have some text to write as-is
                 if (tokenMatch.range.first > start) {
                     components.add(RawComponent(pattern.substring(start, tokenMatch.range.first)))
                 }
 
-                val token = tokenMatch.groupValues[1]
+                //Get the token (remember: groupValues[0] is the whole matched string)
+                //If groupValues[1] is empty, it means we matched a sequence with brackets around it, so get the second group value
+                val token = tokenMatch.groupValues[1].takeUnless(String::isEmpty) ?: tokenMatch.groupValues[2]
 
-                val component = localRegistry[token]
-                if (component != null) {
-                    component.tune(tokenModifierRegex.findAll(tokenMatch.groupValues[3]).map { result -> result.groupValues[1] }.toList())
-                    components.add(component)
+                val componentInitialiser = registry[token]
+                if (componentInitialiser != null) {
+                    //If we have an initialiser, invoke it and add it to the list of components
+                    //The list of modifiers is obtained by finding all valid matches of tokenModifierRegex on the third group value
+                    modifiers.clear()
+                    components.add(componentInitialiser(tokenModifierRegex.findAll(tokenMatch.groupValues[3]).mapTo(modifiers) { result -> result.groupValues[1] }))
                 }
 
+                //Increment our starting position to the end of our match, then recurse and find another match
                 start = tokenMatch.range.last + 1
                 tokenMatch = tokenRegex.find(pattern, start)
             }
 
+            //If the last position we ended at isn't the end of the pattern, we have leftover text to write as is
             if (start < pattern.length) {
                 components.add(RawComponent(pattern.substring(start)))
             }
 
-            return PatternLayout(components.toTypedArray())
+            return PatternLayout(components)
         }
     }
 
@@ -49,4 +104,4 @@ class PatternLayout(val components: Array<PatternComponent>) : Layout {
     }
 }
 
-internal expect val componentRegistry: Map<String, PatternComponent>
+public expect var PatternLayout.Factory.componentRegistry: Map<String, PatternComponentInitialiser>

--- a/src/sawtoothMain/kotlin/lumberjack/sawtooth/layout/PatternLayout.kt
+++ b/src/sawtoothMain/kotlin/lumberjack/sawtooth/layout/PatternLayout.kt
@@ -60,7 +60,7 @@ class PatternLayout(val components: List<PatternComponent>) : Layout {
             val registry =
                 componentRegistry +
                 localRegistry +
-                loggerProperties.associate { key -> Pair(key.name, { PropertyComponent(key) }) }
+                loggerProperties.associate { key -> Pair(key.name, { _: List<String> -> PropertyComponent(key) }) }
 
             var start = 0
             //Find our first match in the pattern


### PR DESCRIPTION
While this currently works fully, it's not necessarily perfect, so let me know what needs to be changed.

This change creates a PatternLayout for Sawtooth configuration that accepts a string such as "%logger: %msg" and tokenises it, allowing custom output.

Each token accepts a set of modifiers, passed via braces "%epoch{ms}"; it is the responsibility of the PatternComponent to parse these modifiers and determine how to process them.